### PR TITLE
实现论坛等级倍率差异化

### DIFF
--- a/common/group-ratio.go
+++ b/common/group-ratio.go
@@ -3,9 +3,11 @@ package common
 import "encoding/json"
 
 var GroupRatio = map[string]float64{
-	"default": 1,
-	"vip":     1,
-	"svip":    1,
+	LinuxDoTrustLevel0: 1,
+	LinuxDoTrustLevel1: 1,
+	LinuxDoTrustLevel2: 1,
+	LinuxDoTrustLevel3: 1,
+	LinuxDoTrustLevel4: 1,
 }
 
 func GroupRatio2JSONString() string {

--- a/common/linuxdo-group.go
+++ b/common/linuxdo-group.go
@@ -1,0 +1,17 @@
+package common
+
+import "fmt"
+
+const (
+	LinuxDoTrustLevel0 = "Level0"
+	LinuxDoTrustLevel1 = "level1"
+	LinuxDoTrustLevel2 = "level2"
+	LinuxDoTrustLevel3 = "level3"
+	LinuxDoTrustLevel4 = "level4"
+)
+
+type TrustLevel int
+
+func (l TrustLevel) String() string {
+	return fmt.Sprintf("level%d", l)
+}

--- a/common/topup-ratio.go
+++ b/common/topup-ratio.go
@@ -3,9 +3,11 @@ package common
 import "encoding/json"
 
 var TopupGroupRatio = map[string]float64{
-	"default": 1,
-	"vip":     1,
-	"svip":    1,
+	LinuxDoTrustLevel0: 1,
+	LinuxDoTrustLevel1: 1,
+	LinuxDoTrustLevel2: 1,
+	LinuxDoTrustLevel3: 1,
+	LinuxDoTrustLevel4: 1,
 }
 
 func TopupGroupRatio2JSONString() string {

--- a/model/user.go
+++ b/model/user.go
@@ -3,9 +3,10 @@ package model
 import (
 	"errors"
 	"fmt"
-	"one-api/common"
 	"strings"
 	"time"
+
+	"one-api/common"
 
 	"gorm.io/gorm"
 )
@@ -29,7 +30,7 @@ type User struct {
 	Quota            int            `json:"quota" gorm:"type:int;default:0"`
 	UsedQuota        int            `json:"used_quota" gorm:"type:int;default:0;column:used_quota"` // used quota
 	RequestCount     int            `json:"request_count" gorm:"type:int;default:0;"`               // request number
-	Group            string         `json:"group" gorm:"type:varchar(64);default:'default'"`
+	Group            string         `json:"group" gorm:"type:varchar(64);default:'level0'"`
 	AffCode          string         `json:"aff_code" gorm:"type:varchar(32);column:aff_code;uniqueIndex"`
 	AffCount         int            `json:"aff_count" gorm:"type:int;default:0;column:aff_count"`
 	AffQuota         int            `json:"aff_quota" gorm:"type:int;default:0;column:aff_quota"`           // 邀请剩余额度

--- a/web/src/helpers/render.js
+++ b/web/src/helpers/render.js
@@ -16,12 +16,12 @@ export function renderGroup(group) {
     groups.sort();
     return <>
         {groups.map((group) => {
-            if (group === 'vip' || group === 'pro') {
+            if (group === 'level3' || group === 'level4') {
                 return <Tag size='large' color='yellow'>{group}</Tag>;
-            } else if (group === 'svip' || group === 'premium') {
+            } else if (group === 'level2' || group === 'level1') {
                 return <Tag size='large' color='red'>{group}</Tag>;
             }
-            if (group === 'default') {
+            if (group === 'level0') {
                 return <Tag size='large'>{group}</Tag>;
             } else {
                 return <Tag size='large' color={stringToColor(group)}>{group}</Tag>;


### PR DESCRIPTION
通过绑定 L站 trust_level 与 oneapi 用户组，管理员为不同分组设置不同倍率，即可实现论坛等级倍率设置。
<img width="300" alt="image" src="https://github.com/linux-do/new-api/assets/35096485/6abc98da-dc5a-48c6-b2cd-638fbdea0cba">

<img width="529" alt="image" src="https://github.com/linux-do/new-api/assets/35096485/03b64fd1-e24c-4347-9d31-ce3961cf613a">


变更：
1. 把原来的 default、vip、svip 调整成为与L站用户等级对应的 level0、level1、level2、level3、level4
2. L站用户等级变更时，重新授权登录便可同步新的等级信息到 oneapi


已知问题：
1. 注册页展示 linuxdo 授权按钮（不过没啥影响）

2. 不会前端，新建渠道默认分组有个 default 没找到哪里删，等前端热佬来看看👀
<img width="250" alt="image" src="https://github.com/linux-do/new-api/assets/35096485/a5a19dbf-b0ea-40e7-b321-48d42f23cf49">


