### PR TITLE
feat: 设置页面为linuxdo用户额外添加等级额度设置

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -105,6 +105,13 @@ var AutomaticEnableChannelEnabled = false
 var QuotaRemindThreshold = 1000
 var PreConsumedQuota = 500
 
+var QuotaForLinuxDoLevel1 = 0
+var QuotaForLinuxDoLevel2 = 0
+var QuotaForLinuxDoLevel3 = 0
+var QuotaForLinuxDoLevel4 = 0
+var LinuxDoUserQuotaRefreshInterval = 24
+var AutomaticRefreshLinuxDoUserQuotaEnabled = false
+
 var RetryTimes = 0
 
 var RootUserEmail = ""

--- a/controller/linuxdo.go
+++ b/controller/linuxdo.go
@@ -191,7 +191,7 @@ func LinuxDoOAuth(c *gin.Context) {
 	// 刷新用户的配额
 	if common.AutomaticRefreshLinuxDoUserQuotaEnabled {
 		TimeStamp := time.Now().Unix()
-		if TimeStamp - user.RefeashTimeStamp > int64(common.LinuxDoUserQuotaRefreshInterval * 60) {
+		if TimeStamp - user.RefeashTimeStamp > int64(common.LinuxDoUserQuotaRefreshInterval * 3600) {
 			model.RefreshUserQuotaAndSave(user.Id, TimeStamp)
 		}
 	}

--- a/controller/linuxdo.go
+++ b/controller/linuxdo.go
@@ -170,6 +170,8 @@ func LinuxDoOAuth(c *gin.Context) {
 				user.Quota -= common.QuotaForLinuxDoLevel3
 		}
 		switch NewTrustLevel {
+			case 1:
+				user.Quota += common.QuotaForLinuxDoLevel1
 			case 2:
 				user.Quota += common.QuotaForLinuxDoLevel2
 			case 3:

--- a/model/cache.go
+++ b/model/cache.go
@@ -197,7 +197,7 @@ func CacheUpdateUserRefreshTimeStamp(id int, timestamp int64) error {
 	if !common.RedisEnabled {
 		return nil
 	}
-	err := common.RedisSet(fmt.Sprintf("user_stamp:%d", id), fmt.Sprintf("%d", timestamp), time.Duration(UserId2QuotaCacheSeconds)*time.Second)
+	err := common.RedisSet(fmt.Sprintf("user_stamp:%d", id), fmt.Sprintf("%d", timestamp), time.Duration(UserId2timeCacheSeconds)*time.Second)
 	return err
 }
 

--- a/model/option.go
+++ b/model/option.go
@@ -79,6 +79,12 @@ func InitOptionMap() {
 	common.OptionMap["QuotaForInviter"] = strconv.Itoa(common.QuotaForInviter)
 	common.OptionMap["QuotaForInvitee"] = strconv.Itoa(common.QuotaForInvitee)
 	common.OptionMap["QuotaRemindThreshold"] = strconv.Itoa(common.QuotaRemindThreshold)
+	common.OptionMap["QuotaForLinuxDoLevel1"] = strconv.Itoa(common.QuotaForLinuxDoLevel1)
+	common.OptionMap["QuotaForLinuxDoLevel2"] = strconv.Itoa(common.QuotaForLinuxDoLevel2)
+	common.OptionMap["QuotaForLinuxDoLevel3"] = strconv.Itoa(common.QuotaForLinuxDoLevel3)
+	common.OptionMap["QuotaForLinuxDoLevel4"] = strconv.Itoa(common.QuotaForLinuxDoLevel4)
+	common.OptionMap["LinuxDoUserQuotaRefreshInterval"] = strconv.Itoa(common.LinuxDoUserQuotaRefreshInterval)
+	common.OptionMap["AutomaticRefreshLinuxDoUserQuotaEnabled"] = strconv.FormatBool(common.AutomaticRefreshLinuxDoUserQuotaEnabled)
 	common.OptionMap["PreConsumedQuota"] = strconv.Itoa(common.PreConsumedQuota)
 	common.OptionMap["ModelRatio"] = common.ModelRatio2JSONString()
 	common.OptionMap["ModelPrice"] = common.ModelPrice2JSONString()
@@ -150,6 +156,8 @@ func updateOptionMap(key string, value string) (err error) {
 	if strings.HasSuffix(key, "Enabled") || key == "DefaultCollapseSidebar" {
 		boolValue := value == "true"
 		switch key {
+		case "AutomaticRefreshLinuxDoUserQuotaEnabled":
+			common.AutomaticRefreshLinuxDoUserQuotaEnabled = boolValue
 		case "PasswordRegisterEnabled":
 			common.PasswordRegisterEnabled = boolValue
 		case "PasswordLoginEnabled":
@@ -254,6 +262,16 @@ func updateOptionMap(key string, value string) (err error) {
 		common.QuotaForInvitee, _ = strconv.Atoi(value)
 	case "QuotaRemindThreshold":
 		common.QuotaRemindThreshold, _ = strconv.Atoi(value)
+	case "QuotaForLinuxDoLevel1":
+		common.QuotaForLinuxDoLevel1, _ = strconv.Atoi(value)
+	case "QuotaForLinuxDoLevel2":
+		common.QuotaForLinuxDoLevel2, _ = strconv.Atoi(value)
+	case "QuotaForLinuxDoLevel3":
+		common.QuotaForLinuxDoLevel3, _ = strconv.Atoi(value)
+	case "QuotaForLinuxDoLevel4":
+		common.QuotaForLinuxDoLevel4, _ = strconv.Atoi(value)
+	case "LinuxDoUserQuotaRefreshInterval":
+		common.LinuxDoUserQuotaRefreshInterval, _ = strconv.Atoi(value)
 	case "PreConsumedQuota":
 		common.PreConsumedQuota, _ = strconv.Atoi(value)
 	case "RetryTimes":

--- a/web/src/components/OperationSetting.js
+++ b/web/src/components/OperationSetting.js
@@ -28,7 +28,13 @@ const OperationSetting = () => {
         DataExportDefaultTime: 'hour',
         DataExportInterval: 5,
         DefaultCollapseSidebar: '', // 默认折叠侧边栏
-        RetryTimes: 0
+        RetryTimes: 0,
+        QuotaForLinuxDoLevel1: 0,
+        QuotaForLinuxDoLevel2: 0,
+        QuotaForLinuxDoLevel3: 0,
+        QuotaForLinuxDoLevel4: 0,
+        LinuxDoUserQuotaRefreshInterval: 24,
+        AutomaticRefreshLinuxDoUserQuotaEnabled: ''
     });
     const [originInputs, setOriginInputs] = useState({});
     let [loading, setLoading] = useState(false);
@@ -139,6 +145,23 @@ const OperationSetting = () => {
                 }
                 if (originInputs['PreConsumedQuota'] !== inputs.PreConsumedQuota) {
                     await updateOption('PreConsumedQuota', inputs.PreConsumedQuota);
+                }
+                break;
+            case 'linuxdoquota':
+                if (originInputs['QuotaForLinuxDoLevel1'] !== inputs.QuotaForLinuxDoLevel1) {
+                    await updateOption('QuotaForLinuxDoLevel1', inputs.QuotaForLinuxDoLevel1);
+                }
+                if (originInputs['QuotaForLinuxDoLevel2'] !== inputs.QuotaForLinuxDoLevel2) {
+                    await updateOption('QuotaForLinuxDoLevel2', inputs.QuotaForLinuxDoLevel2);
+                }
+                if (originInputs['QuotaForLinuxDoLevel3'] !== inputs.QuotaForLinuxDoLevel3) {
+                    await updateOption('QuotaForLinuxDoLevel3', inputs.QuotaForLinuxDoLevel3);
+                }
+                if (originInputs['QuotaForLinuxDoLevel4'] !== inputs.QuotaForLinuxDoLevel4) {
+                    await updateOption('QuotaForLinuxDoLevel4', inputs.QuotaForLinuxDoLevel4);
+                }
+                if (originInputs['LinuxDoUserQuotaRefreshInterval'] !== inputs.LinuxDoUserQuotaRefreshInterval) {
+                    await updateOption('LinuxDoUserQuotaRefreshInterval', inputs.LinuxDoUserQuotaRefreshInterval);
                 }
                 break;
             case 'general':
@@ -403,6 +426,73 @@ const OperationSetting = () => {
                     <Form.Button onClick={() => {
                         submitConfig('quota').then();
                     }}>保存额度设置</Form.Button>
+                    <Divider/>
+                    <Header as='h3'>
+                        Linuxdo 用户额外额度设置
+                    </Header>
+                    <Form.Checkbox
+                        checked={inputs.AutomaticRefreshLinuxDoUserQuotaEnabled === 'true'}
+                        label='启用 Linuxdo 用户额度自动更新（关闭时不会定时自动补充用户额度）'
+                        name='AutomaticRefreshLinuxDoUserQuotaEnabled'
+                        onChange={handleInputChange}
+                    />
+                    <Form.Group widths={5}>
+                        <Form.Input
+                            label='1级用户额度'
+                            name='QuotaForLinuxDoLevel1'
+                            onChange={handleInputChange}
+                            autoComplete='new-password'
+                            value={inputs.QuotaForLinuxDoLevel1}
+                            type='number'
+                            min='0'
+                            placeholder='例如：250000'
+                        />
+                        <Form.Input
+                            label='2级用户额度'
+                            name='QuotaForLinuxDoLevel2'
+                            onChange={handleInputChange}
+                            autoComplete='new-password'
+                            value={inputs.QuotaForLinuxDoLevel2}
+                            type='number'
+                            min='0'
+                            placeholder='例如：1000000'
+                        />
+                        <Form.Input
+                            label='3级用户额度'
+                            name='QuotaForLinuxDoLevel3'
+                            onChange={handleInputChange}
+                            autoComplete='new-password'
+                            value={inputs.QuotaForLinuxDoLevel3}
+                            type='number'
+                            min='0'
+                            placeholder='例如：4000000'
+                        />
+                        <Form.Input
+                            label='4级用户额度'
+                            name='QuotaForLinuxDoLevel4'
+                            onChange={handleInputChange}
+                            autoComplete='new-password'
+                            value={inputs.QuotaForLinuxDoLevel4}
+                            type='number'
+                            min='0'
+                            placeholder='例如：16000000'
+                        />
+                        <Form.Input
+                            label='Linuxdo 用户额度更新间隔（小时）'
+                            name='LinuxDoUserQuotaRefreshInterval'
+                            type={'number'}
+                            step='1'
+                            min='1'
+                            onChange={handleInputChange}
+                            autoComplete='new-password'
+                            value={inputs.LinuxDoUserQuotaRefreshInterval}
+                            placeholder='Linuxdo 用户额度更新间隔（小时）'
+                        />
+
+                    </Form.Group>
+                    <Form.Button onClick={() => {
+                        submitConfig('linuxdoquota').then();
+                    }}>保存 Linuxdo 用户额外额度设置</Form.Button>
                     <Divider/>
                     <Header as='h3'>
                         倍率设置


### PR DESCRIPTION
1. 设置页面添加等级额度设置
 ![image-20240316092143328](https://s2.loli.net/2024/03/16/okl8amh6ZT7YLUu.png)
2. 自动更新用户额度，用于限额
不开启自动刷新，则额外额度是一次性的。开启自动刷新后，每个用户定时补充可用额度，使用lazy机制，即只有调用api或者登陆时才会去检查到达需要补充可用额度的时间，可用额度不会累加，用作日限额（demo里的更新间隔是一分钟）
![image-20240316092717144](https://s2.loli.net/2024/03/16/U7Rnp2lohHLIYQv.png)
![image-20240316092800436](https://s2.loli.net/2024/03/16/R2qbMVo4JIG7gjA.png)
![image-20240316092812573](https://s2.loli.net/2024/03/16/IBxC3n6fSY1LRHc.png)
![image-20240316100043023](https://s2.loli.net/2024/03/16/V51exvjcmSw9HpZ.png)

可能的问题：
1. 0级用户没人权（即被我除外了），所以不知道使用0级用户是否会出问题
2. 用户信任等级刷新后需要重新登录以更新，且未测试绑定linux.do账号后，再使用原有账号登陆，而不是走linux.do账号登录时是否会去检查信任等级的变化并补充可用额度(大概率不会？，如果不会的话，linuxdo.go最后一段刷新用户的配额和信任等级代码需要后移至setupLogin函数里)
3. 如果用户正好把额度用完了，则再调用api时因为会在前期检测时返回，所以不会自动去检查是否需要补充可用额度，用户需要重新登录(一般很少见？)